### PR TITLE
Update gh-pages workflow's run-on to ubuntu-latest

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     timeout-minutes: 10
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout amaki-aria.github.io
         uses: actions/checkout@v2


### PR DESCRIPTION
大概原因可能是 `ubuntu-20.04` 已经被 GitHub 下了，这个 PR 把 `runs-on` 改成 `ubuntu-latest`。